### PR TITLE
Feat User 목록 구현, email과 name기반으로 검색 구현

### DIFF
--- a/src/main/java/com/example/idus_exam/user/UserController.java
+++ b/src/main/java/com/example/idus_exam/user/UserController.java
@@ -38,4 +38,25 @@ public class UserController {
     public ResponseEntity<List<UserDto.OrdersResponse>> orders(@AuthenticationPrincipal User user) {
         return userService.getUserOrders(user);
     }
+
+    @Operation(summary = "유저 목록 조회", description = "유저 목록을 페이지와 크기를 받아 전달한다")
+    @Transactional(readOnly = true)
+    @GetMapping("/list")
+    public ResponseEntity<List<UserDto.UserListResponse>> list(int page, int size) {
+        return userService.getUserList(page, size);
+    }
+
+    @Operation(summary = "유저 목록 조회", description = "유저 목록을 페이지와 크기를 받아 전달한다")
+    @Transactional(readOnly = true)
+    @GetMapping("/list/email")
+    public ResponseEntity<List<UserDto.UserListResponse>> listEmail(int page, int size, String email) {
+        return userService.getUserListByEmail(page, size, email);
+    }
+
+    @Operation(summary = "유저 목록 조회", description = "유저 목록을 페이지와 크기를 받아 전달한다")
+    @Transactional(readOnly = true)
+    @GetMapping("/list/name")
+    public ResponseEntity<List<UserDto.UserListResponse>> listName(int page, int size, String name) {
+        return userService.getUserListByName(page, size, name);
+    }
 }

--- a/src/main/java/com/example/idus_exam/user/UserRepository.java
+++ b/src/main/java/com/example/idus_exam/user/UserRepository.java
@@ -1,10 +1,15 @@
 package com.example.idus_exam.user;
 
 import com.example.idus_exam.user.model.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
+    Page<User> findAllByEmailContaining(Pageable pageable, String email);
+    Page<User> findAllByNameContaining(Pageable pageable, String name);
 }

--- a/src/main/java/com/example/idus_exam/user/UserService.java
+++ b/src/main/java/com/example/idus_exam/user/UserService.java
@@ -5,6 +5,8 @@ import com.example.idus_exam.user.model.User;
 import com.example.idus_exam.user.model.UserDto;
 import lombok.RequiredArgsConstructor;
 import org.apache.coyote.Response;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -24,6 +26,7 @@ public class UserService implements UserDetailsService {
         return userRepository.findByEmail(username).orElseThrow(() -> new UsernameNotFoundException(username));
     }
 
+    //회원 가입
     public ResponseEntity<String> signup(UserDto.SignupRequest dto) {
         User user = dto.toEntity();
         user.setPassword(passwordEncoder.encode(user.getPassword()));
@@ -31,14 +34,34 @@ public class UserService implements UserDetailsService {
         return ResponseEntity.ok("Signup successful");
     }
 
+    //유저 상세 정보
     public ResponseEntity<UserDto.DetailResponse> getUserDetail(User user) {
         User result = userRepository.findById(user.getIdx()).orElseThrow();
         return ResponseEntity.ok(UserDto.DetailResponse.from(result));
     }
 
+    //유저 주문 목록
     public ResponseEntity<List<UserDto.OrdersResponse>> getUserOrders(User user) {
         User result = userRepository.findById(user.getIdx()).orElseThrow();
         List<Orders> ordersList = result.getOrdersList();
         return ResponseEntity.ok(UserDto.OrdersResponse.from(ordersList));
+    }
+
+    //유저 목록
+    public ResponseEntity<List<UserDto.UserListResponse>> getUserList(int page, int size) {
+        Page<User> users = userRepository.findAll(PageRequest.of(page, size));
+        return ResponseEntity.ok(UserDto.UserListResponse.from(users.getContent()));
+    }
+
+    //유저 목록 이메일로
+    public ResponseEntity<List<UserDto.UserListResponse>> getUserListByEmail(int  page, int size, String email) {
+        Page<User> users = userRepository.findAllByEmailContaining(PageRequest.of(page, size), email);
+        return ResponseEntity.ok(UserDto.UserListResponse.from(users.getContent()));
+    }
+
+    //유저 목록 이름으로
+    public ResponseEntity<List<UserDto.UserListResponse>> getUserListByName(int  page, int size, String name) {
+        Page<User> users = userRepository.findAllByNameContaining(PageRequest.of(page, size), name);
+        return ResponseEntity.ok(UserDto.UserListResponse.from(users.getContent()));
     }
 }

--- a/src/main/java/com/example/idus_exam/user/model/UserDto.java
+++ b/src/main/java/com/example/idus_exam/user/model/UserDto.java
@@ -103,5 +103,47 @@ public class UserDto {
         }
     }
 
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UserListResponse {
+        private Long idx;
+        private String name;
+        private String email;
+        private String phoneNumber;
+        private String nickname;
+        private String gender;
+        private OrdersResponse lastOrder;
+        public static UserListResponse from(User user) {
+            List<Orders> ordersList = user.getOrdersList();
+            Orders last = null;
+            OrdersResponse lastOrder = null;
+            if(!ordersList.isEmpty()) {
+                last = ordersList.get(0);
+                for(Orders order : ordersList) {
+                    if(order.getOrderDate().isAfter(last.getOrderDate())) {
+                        last = order;
+                    }
+                }
+                lastOrder = OrdersResponse.from(last);
+            }
+
+            return UserListResponse.builder()
+                    .idx(user.getIdx())
+                    .name(user.getName())
+                    .email(user.getEmail())
+                    .phoneNumber(user.getPhoneNumber())
+                    .nickname(user.getNickname())
+                    .gender(user.getGender())
+                    .lastOrder(lastOrder)
+                    .build();
+        }
+
+        public static List<UserListResponse> from(List<User> users) {
+            return users.stream().map(UserListResponse::from).collect(Collectors.toList());
+        }
+    }
+
 
 }


### PR DESCRIPTION

## #️⃣ Issue Number

#7 

## 📝 요약(Summary)

모든 함수가 page와 size를 받아 페이지네이션 적용
/user/list로 접근
유저 상세와 유저 최근 주문을 전달
주문이 없다면 null 값으로 전달
/user/list/email
email을 기반으로
유저 상세와 유저 최근 주문을 전달
주문이 없다면 null 값으로 전달
user/list/name
name을 기반으로
유저 상세와 유저 최근 주문을 전달
주문이 없다면 null 값으로 전달-->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

close #7 